### PR TITLE
Added user specificity to Logins page

### DIFF
--- a/src/api/loginData.js
+++ b/src/api/loginData.js
@@ -2,9 +2,9 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
-const getAllLogins = () =>
+const getAllLoginsByUserId = (userId) =>
   new Promise((resolve, reject) => {
-    fetch(`${endpoint}/api/logins`, {
+    fetch(`${endpoint}/api/logins/user/${userId}`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -77,4 +77,4 @@ const deleteLogin = async (id) => {
   return response.json();
 };
 
-export { getAllLogins, getLoginById, createLogin, updateLogin, deleteLogin };
+export { getAllLoginsByUserId, getLoginById, createLogin, updateLogin, deleteLogin };

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useAuth } from '@/utils/context/authContext';
-import { getAllLogins } from '@/api/loginData';
+import { getAllLoginsByUserId } from '@/api/loginData';
 import LoginCard from '@/components/LoginCard';
 
 function Home() {
@@ -11,7 +11,7 @@ function Home() {
   const { user } = useAuth();
 
   const refreshLogins = () => {
-    getAllLogins().then((fetchedLogins) => {
+    getAllLoginsByUserId(user.id).then((fetchedLogins) => {
       const sortedLogins = fetchedLogins.sort((a, b) => a.vendorName.localeCompare(b.vendorName));
       setLogins(sortedLogins);
     });


### PR DESCRIPTION
Description

- [ ]  Changed getAllLogins call to getAllLoginsByUserId
- [ ] Updated useEffect in homepage page.js to use getAllLoginsByUserId call so that the list of vendor logins displayed would be user-specific

## Related Issue

#8 #11 

Motivation and Context

Users must be able to view only vendor login credentials that they have entered.


How Can This Be Tested?

Pull down and test manually


Screenshots (if appropriate):

N/A


Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
